### PR TITLE
Add configuration option to disable export task

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ LokaliseRails::GlobalConfig.config do |c|
 
   ## Infer language ISO code for the translation file:
   ## c.lang_iso_inferer = ->(data, _path) { YAML.safe_load(data)&.keys&.first }
+
+  ## Disable the export rake task:
+  ## c.disable_export_task = false
 end
 ```
 

--- a/lib/generators/templates/lokalise_rails_config.rb
+++ b/lib/generators/templates/lokalise_rails_config.rb
@@ -55,5 +55,8 @@ if defined?(LokaliseRails::GlobalConfig)
 
     ## Infer language ISO code for the translation file:
     ## c.lang_iso_inferer = ->(data, _path) { YAML.safe_load(data)&.keys&.first }
+
+    ## Disable the export rake task:
+    ## c.disable_export_task = false
   end
 end

--- a/lib/lokalise_rails/global_config.rb
+++ b/lib/lokalise_rails/global_config.rb
@@ -5,6 +5,17 @@ module LokaliseRails
   # specific to the LokaliseRails gem in a Rails application.
   class GlobalConfig < LokaliseManager::GlobalConfig
     class << self
+      attr_accessor :disable_export_task
+
+      # Returns whether the export task should be disabled.
+      #
+      # Defaults to `false` if not explicitly set.
+      #
+      # @return [Boolean] `true` if the export task is disabled, otherwise `false`.
+      def disable_export_task
+        @disable_export_task ||= false
+      end
+
       # Returns the path to the directory where translation files are stored.
       #
       # Defaults to `config/locales` under the Rails application root if not explicitly set.

--- a/lib/tasks/lokalise_rails_tasks.rake
+++ b/lib/tasks/lokalise_rails_tasks.rake
@@ -20,17 +20,19 @@ namespace :lokalise_rails do
     abort "Import failed: #{e.message}"
   end
 
-  # Exports translations from the Rails project to Lokalise.
-  #
-  # Uses LokaliseManager to push localization files based on the configuration
-  # in `LokaliseRails::GlobalConfig`.
-  #
-  # @raise [StandardError] Prints an error message and aborts if the export fails.
-  desc 'Export translations from the Rails project to Lokalise'
-  task :export do
-    exporter = LokaliseManager.exporter({}, LokaliseRails::GlobalConfig)
-    exporter.export!
-  rescue StandardError => e
-    abort "Export failed: #{e.message}"
+  unless LokaliseRails::GlobalConfig.disable_export_task
+    # Exports translations from the Rails project to Lokalise.
+    #
+    # Uses LokaliseManager to push localization files based on the configuration
+    # in `LokaliseRails::GlobalConfig`.
+    #
+    # @raise [StandardError] Prints an error message and aborts if the export fails.
+    desc 'Export translations from the Rails project to Lokalise'
+    task :export do
+      exporter = LokaliseManager.exporter({}, LokaliseRails::GlobalConfig)
+      exporter.export!
+    rescue StandardError => e
+      abort "Export failed: #{e.message}"
+    end
   end
 end

--- a/spec/lib/lokalise_rails/global_config_spec.rb
+++ b/spec/lib/lokalise_rails/global_config_spec.rb
@@ -146,5 +146,10 @@ describe LokaliseRails::GlobalConfig do
       fake_class.lang_iso_inferer = runner
       expect(fake_class).to have_received(:lang_iso_inferer=)
     end
+
+    it 'is possible to disable the export task' do
+      described_class.disable_export_task = true
+      expect(described_class.disable_export_task).to be true
+    end
   end
 end


### PR DESCRIPTION
Resolves: #15 

### Problem

The `lokalise_rails` gem currently lacks a built-in mechanism to disable the `lokalise_rails:export` rake task. This can lead to accidental execution of the export task, potentially syncing unwanted keys to Lokalise and disrupting the project structure. While a read-only API key could mitigate this, it is not an ideal solution for teams that want to enforce stricter safeguards.

### Solution

This PR introduces a new global configuration option, `disable_export_task`, to the `LokaliseRails::GlobalConfig` class. When set to `true`, the `lokalise_rails:export` rake task will not be loaded, effectively disabling it. This provides a simple and effective way to prevent accidental exports.